### PR TITLE
feat: add examples for Omni client usage and refactor auth helpers

### DIFF
--- a/pkg/access/access.go
+++ b/pkg/access/access.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package access contains commands related to API access for the client.
+package access

--- a/pkg/access/auth.go
+++ b/pkg/access/auth.go
@@ -1,0 +1,198 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package access
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	pgpcrypto "github.com/ProtonMail/gopenpgp/v2/crypto"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/pkg/browser"
+	authcli "github.com/siderolabs/go-api-signature/pkg/client/auth"
+	"github.com/siderolabs/go-api-signature/pkg/client/interceptor"
+	"github.com/siderolabs/go-api-signature/pkg/message"
+	"github.com/siderolabs/go-api-signature/pkg/pgp"
+	"github.com/siderolabs/go-api-signature/pkg/pgp/client"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/siderolabs/omni-client/pkg/client/omni"
+	authres "github.com/siderolabs/omni-client/pkg/omni/resources/auth"
+	"github.com/siderolabs/omni-client/pkg/version"
+)
+
+// ServiceAccountKey is the JSON representation of a service account key.
+type ServiceAccountKey struct {
+	// Name is the name (identity) of the service account key.
+	Name string `json:"name"`
+
+	// PGPKey is the armored PGP private key.
+	PGPKey string `json:"pgp_key"`
+}
+
+// AuthInterceptorConfig defines Omni auth gRPC interceptors config.
+type AuthInterceptorConfig struct {
+	provider *client.KeyProvider
+
+	// signer is the static signer to use if the config is sourced from the env variable ServiceAccountKeyEnvVar.
+	signer message.Signer
+
+	contextName string
+	identity    string
+
+	// envSource is set to true if the config is sourced from the environment variable ServiceAccountKeyEnvVar.
+	envSource bool
+}
+
+// NewAuthInterceptorConfig creates new auth interceptor.
+func NewAuthInterceptorConfig(contextName, identity, serviceAccountKey string) (*AuthInterceptorConfig, error) {
+	if serviceAccountKey != "" {
+		envIdentity, signer, err := parseServiceAccountKey(serviceAccountKey)
+		if err != nil {
+			return nil, err
+		}
+
+		return &AuthInterceptorConfig{
+			envSource: true,
+			identity:  envIdentity,
+			signer:    signer,
+		}, nil
+	}
+
+	return &AuthInterceptorConfig{
+		envSource:   false,
+		provider:    client.NewKeyProvider("omni/keys"),
+		contextName: contextName,
+		identity:    identity,
+	}, nil
+}
+
+// Interceptor creates gRPC interceptor.
+func (c *AuthInterceptorConfig) Interceptor() *interceptor.Signature {
+	signerFunc := func(ctx context.Context, cc *grpc.ClientConn) (message.Signer, error) {
+		// if the source is an environment variable, we can just return the static signer.
+		if c.envSource {
+			return c.signer, nil
+		}
+
+		return c.provider.ReadValidKey(c.contextName, c.identity)
+	}
+
+	// only attempt renews if config is not sourced from the env variables
+	var renewSignerFunc interceptor.SignerFunc
+
+	if !c.envSource {
+		renewSignerFunc = func(ctx context.Context, cc *grpc.ClientConn) (message.Signer, error) {
+			return c.authenticate(ctx, cc)
+		}
+	}
+
+	authEnabledFunc := func(ctx context.Context, cc *grpc.ClientConn) (bool, error) {
+		st := omni.NewClient(cc).State()
+		confPtr := authres.NewAuthConfig().Metadata()
+
+		// clear the outgoing metadata to prevent the request from being proxied to the Talos backend
+		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs())
+
+		authConfig, err := safe.StateGet[*authres.Config](ctx, st, confPtr)
+		if err != nil {
+			return false, err
+		}
+
+		enabled := authConfig.TypedSpec().Value.GetAuth0().GetEnabled() || authConfig.TypedSpec().Value.GetWebauthn().GetEnabled()
+
+		return enabled, nil
+	}
+
+	return interceptor.NewSignature(c.identity, signerFunc, renewSignerFunc, authEnabledFunc)
+}
+
+func (c *AuthInterceptorConfig) authenticate(ctx context.Context, cc *grpc.ClientConn) (*client.Key, error) {
+	ctx = context.WithValue(ctx, interceptor.SkipInterceptorContextKey{}, struct{}{})
+
+	authCli := authcli.NewClient(cc)
+
+	err := c.provider.DeleteKey(c.contextName, c.identity)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	pgpKey, err := c.provider.GenerateKey(c.contextName, c.identity, version.Name+" "+version.Tag)
+	if err != nil {
+		return nil, err
+	}
+
+	publicKey, err := pgpKey.ArmorPublic()
+	if err != nil {
+		return nil, err
+	}
+
+	loginURL, err := authCli.RegisterPGPPublicKey(ctx, c.identity, []byte(publicKey))
+	if err != nil {
+		return nil, err
+	}
+
+	savePath, err := c.provider.WriteKey(pgpKey)
+	if err != nil {
+		return nil, err
+	}
+
+	printLoginDialog := func() {
+		fmt.Fprintf(os.Stderr, "Please visit this page to authenticate with omni: %s\n", loginURL)
+	}
+
+	browserEnv := os.Getenv("BROWSER")
+	if browserEnv == "echo" {
+		printLoginDialog()
+	} else {
+		err = browser.OpenURL(loginURL)
+		if err != nil {
+			printLoginDialog()
+		}
+	}
+
+	publicKeyID := pgpKey.Key.Fingerprint()
+
+	err = authCli.AwaitPublicKeyConfirmation(ctx, publicKeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprintf(os.Stderr, "Public key %s is now registered for user %s\n", publicKeyID, c.identity)
+
+	fmt.Fprintf(os.Stderr, "PGP key saved to %s\n", savePath)
+
+	return pgpKey, nil
+}
+
+func parseServiceAccountKey(value string) (string, message.Signer, error) {
+	saKeyJSON, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var saKey ServiceAccountKey
+
+	err = json.Unmarshal(saKeyJSON, &saKey)
+	if err != nil {
+		return "", nil, err
+	}
+
+	cryptoKey, err := pgpcrypto.NewKeyFromArmored(saKey.PGPKey)
+	if err != nil {
+		return "", nil, err
+	}
+
+	key, err := pgp.NewKey(cryptoKey)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return saKey.Name, key, nil
+}

--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -7,8 +7,6 @@ package client
 import (
 	"context"
 	"encoding/base64"
-
-	"google.golang.org/grpc"
 )
 
 // BasicAuth adds basic auth for each gRPC request.
@@ -28,11 +26,4 @@ func (c BasicAuth) GetRequestMetadata(context.Context, ...string) (map[string]st
 // RequireTransportSecurity implements credentials.PerRPCCredentials.
 func (c BasicAuth) RequireTransportSecurity() bool {
 	return true
-}
-
-// WithBasicAuth creates option which adds basic auth to gRPC requests.
-func WithBasicAuth(auth string) grpc.DialOption {
-	return grpc.WithPerRPCCredentials(BasicAuth{
-		auth: auth,
-	})
 }

--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client_test
+
+import (
+	"context"
+	"log"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/siderolabs/omni-client/pkg/client"
+	"github.com/siderolabs/omni-client/pkg/omni/resources"
+	"github.com/siderolabs/omni-client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni-client/pkg/template"
+	"github.com/siderolabs/omni-client/pkg/version"
+)
+
+//nolint:wsl,testableexamples
+func Example() {
+	// This example shows how to use Omni client to access resources.
+
+	// Setup versions information. You can embed that into `go build` too.
+	version.Name = "omni"
+	version.SHA = "build SHA"
+	version.Tag = "v0.9.1"
+
+	// For this example we will use Omni service account.
+	// You can create your service account in advance:
+	//
+	// omnictl serviceaccount create example.account
+	// Created service account "example.account" with public key ID "<REDACTED>"
+	//
+	// Set the following environment variables to use the service account:
+	// OMNI_ENDPOINT=https://<account>.omni.siderolabs.io:443
+	// OMNI_SERVICE_ACCOUNT_KEY=base64encodedkey
+	//
+	// Note: Store the service account key securely, it will not be displayed again
+
+	ctx := context.Background()
+
+	// Creating a new client.
+	client, err := client.New(ctx, "https://<account>.omni.siderolabs.io:443", client.WithServiceAccount(
+		"automation", // This is context name, same as Talos or Kubernetes context, it can be named any way, but should be unique for each account
+		// as Omni client stores generated keys there.
+		"example.account",  // From the generated service account.
+		"base64encodedkey", // From the generated service account.
+	))
+	if err != nil {
+		log.Fatalf("failed to create omni client %s", err)
+	}
+
+	// Omni service is using COSI https://github.com/cosi-project/runtime/.
+	// The same client is used to get resources in Talos.
+	st := client.Omni().State()
+
+	// Getting the resources from the Omni state.
+	machines, err := safe.StateList[*omni.MachineStatus](ctx, st, omni.NewMachineStatus(resources.DefaultNamespace, "").Metadata())
+	if err != nil {
+		log.Fatalf("failed to get machines %s", err)
+	}
+
+	var (
+		cluster string
+		machine *omni.MachineStatus
+	)
+
+	for iter := safe.IteratorFromList(machines); iter.Next(); {
+		item := iter.Value()
+
+		log.Printf("machine %s, connected: %t", item.Metadata(), item.TypedSpec().Value.GetConnected())
+
+		// Check cluster assignment for a machine.
+		// Find a machine which is allocated into a cluster for the later use.
+		if c, ok := item.Metadata().Labels().Get(omni.LabelCluster); ok && machine == nil {
+			cluster = c
+			machine = item
+		}
+	}
+
+	// Creating an empty cluster via template.
+	// Alternative is to use template.Load to load a cluster template.
+	template := template.WithCluster("example.cluster")
+
+	if _, err = template.Sync(ctx, st); err != nil {
+		log.Fatalf("failed to sync cluster %s", err)
+	}
+
+	log.Printf("sync cluster")
+
+	// Delete cluster.
+	if _, err = template.Delete(ctx, st); err != nil {
+		log.Fatalf("failed to delete the cluster %s", err)
+	}
+
+	log.Printf("destroyed cluster")
+
+	// No machines found, exit.
+	if machine == nil {
+		log.Printf("no allocated machines found, exit")
+
+		return
+	}
+
+	// Using Talos through Omni.
+	// Use cluster and machine which we previously found.
+	cpuInfo, err := client.Talos().WithCluster(
+		cluster,
+	).WithNodes(
+		machine.Metadata().ID(), // You can use machine UUID as Omni will properly resolve it into machine IP.
+	).CPUInfo(ctx, &emptypb.Empty{})
+	if err != nil {
+		log.Fatalf("failed to read machine CPU info %s", err)
+	}
+
+	for _, message := range cpuInfo.Messages {
+		for i, info := range message.CpuInfo {
+			log.Printf("machine %s, CPU %d family %s", machine.Metadata(), i, info.CpuFamily)
+		}
+
+		if len(message.CpuInfo) == 0 {
+			log.Printf("no CPU info for machine %s", machine.Metadata())
+		}
+	}
+
+	// Talking to Omni specific APIs: getting talosconfig.
+	_, err = client.Management().Talosconfig(ctx)
+	if err != nil {
+		log.Fatalf("failed to get talosconfig %s", err)
+	}
+}

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package client provides Omni API client.
+package client
+
+import (
+	"google.golang.org/grpc"
+
+	"github.com/siderolabs/omni-client/pkg/access"
+)
+
+// Option is the function that generates gRPC dial options.
+type Option func() ([]grpc.DialOption, error)
+
+// WithBasicAuth creates the client with basic auth.
+func WithBasicAuth(auth string) Option {
+	return func() ([]grpc.DialOption, error) {
+		return []grpc.DialOption{grpc.WithPerRPCCredentials(BasicAuth{
+			auth: auth,
+		})}, nil
+	}
+}
+
+// WithServiceAccount creates the client for a context with identity and service account key.
+func WithServiceAccount(contextName, identity, key string) Option {
+	return func() ([]grpc.DialOption, error) {
+		interceptorConfig, err := access.NewAuthInterceptorConfig(contextName, identity, key)
+		if err != nil {
+			return nil, err
+		}
+
+		authInterceptor := interceptorConfig.Interceptor()
+
+		return []grpc.DialOption{
+			grpc.WithUnaryInterceptor(authInterceptor.Unary()),
+			grpc.WithStreamInterceptor(authInterceptor.Stream()),
+		}, nil
+	}
+}
+
+// WithUserAccount used for accessing Omni by a human.
+func WithUserAccount(contextName, identity string) Option {
+	return func() ([]grpc.DialOption, error) {
+		interceptorConfig, err := access.NewAuthInterceptorConfig(contextName, identity, "")
+		if err != nil {
+			return nil, err
+		}
+
+		authInterceptor := interceptorConfig.Interceptor()
+
+		return []grpc.DialOption{
+			grpc.WithUnaryInterceptor(authInterceptor.Unary()),
+			grpc.WithStreamInterceptor(authInterceptor.Stream()),
+		}, nil
+	}
+}
+
+// WithGrpcOpts creates the client with basic auth.
+func WithGrpcOpts(opts ...grpc.DialOption) Option {
+	return func() ([]grpc.DialOption, error) {
+		return opts, nil
+	}
+}

--- a/pkg/example_test.go
+++ b/pkg/example_test.go
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package pkg_test
+
+import (
+	"os"
+
+	"github.com/siderolabs/omni-client/pkg/omnictl"
+	"github.com/siderolabs/omni-client/pkg/version"
+)
+
+//nolint:wsl,testableexamples
+func Example() {
+	// This is an example of building omnictl executable.
+
+	version.Name = "omni"
+	version.SHA = "build SHA" // Optional.
+	version.Tag = "v0.9.1"    // Required: omnictl validates that server major.minor version are the same as the client.
+
+	// You can disable this validation and warnings by setting:
+	// version.SuppressVersionWarning = true
+
+	// Initialize Root cmd version.
+	omnictl.RootCmd.Version = version.Tag
+
+	// Run Root command.
+	if err := omnictl.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/pkg/omnictl/serviceaccount.go
+++ b/pkg/omnictl/serviceaccount.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/go-api-signature/pkg/pgp"
 	"github.com/spf13/cobra"
 
+	pkgaccess "github.com/siderolabs/omni-client/pkg/access"
 	"github.com/siderolabs/omni-client/pkg/client"
 	"github.com/siderolabs/omni-client/pkg/omnictl/internal/access"
 )
@@ -188,7 +189,7 @@ func encodeServiceAccountKey(name string, key *pgp.Key) (string, error) {
 		return "", fmt.Errorf("failed to armor private key: %w", err)
 	}
 
-	saKey := access.ServiceAccountKey{
+	saKey := pkgaccess.ServiceAccountKey{
 		Name:   name,
 		PGPKey: armoredPrivateKey,
 	}


### PR DESCRIPTION
Implement higher level auth helpers for Omni client. Now instead of passing raw `grpc.DialOption` it is possible to pass helpers that generate `grpc.DialOption` set.

Then client now gets `client.WithServiceAccount(contextName, user, key)` option, that sets up interceptors that set up service account authentication.